### PR TITLE
Finer grained errors

### DIFF
--- a/lib/orientdb4r.rb
+++ b/lib/orientdb4r.rb
@@ -90,6 +90,10 @@ module Orientdb4r
   # e.g. connection broken pipe
   class NodeError < OrientdbError; end
 
+  ###
+  # Error indicating the client has attempted to perform an illegal operation.
+  class ClientError < OrientdbError; end
+
 end
 
 

--- a/lib/orientdb4r/client.rb
+++ b/lib/orientdb4r/client.rb
@@ -229,7 +229,7 @@ module Orientdb4r
         response = get_database
         children = response['classes'].select { |i| i['superClass'] == name }
         unless children.empty?
-          raise OrientdbError, "class is super-class, cannot be deleted, name=#{name}"
+          raise ClientError, "class is super-class, cannot be deleted, name=#{name}"
         end
       end
 

--- a/lib/orientdb4r/client.rb
+++ b/lib/orientdb4r/client.rb
@@ -317,7 +317,7 @@ module Orientdb4r
           query_log("Orientdb4r::Client#call_server", URI.decode(debug_string))
         end
         idx = lb_strategy.node_index
-        raise OrientdbError, lb_all_bad_msg if idx.nil? # no good node found
+        raise ConnectionError, lb_all_bad_msg if idx.nil? # no good node found
 
         begin
           node = @nodes[idx]
@@ -334,7 +334,7 @@ module Orientdb4r
           end
         end until idx.nil? and response.nil? # both 'nil' <= we tried all nodes and all with problem
 
-        raise OrientdbError, lb_all_bad_msg
+        raise ConnectionError, lb_all_bad_msg
       end
 
 

--- a/lib/orientdb4r/rest/client.rb
+++ b/lib/orientdb4r/rest/client.rb
@@ -438,7 +438,7 @@ module Orientdb4r
           when content_type.start_with?('application/json')
             ::JSON.parse(response.body)
           else
-            raise OrientdbError, "unsuported content type: #{content_type}"
+            raise OrientdbError, "unsupported content type: #{content_type}"
           end
 
         rslt
@@ -461,14 +461,14 @@ module Orientdb4r
 
         # raise problem if other code than 200
         if options[:mode] == :strict and 200 != response.code
-          raise OrientdbError, "unexpeted return code, code=#{response.code}"
+          raise OrientdbError, "unexpected return code, code=#{response.code}"
         end
         # log warning if other than 200 and raise problem if other code than 'Successful 2xx'
         if options[:mode] == :warning
           if 200 != response.code and 2 == (response.code / 100)
             Orientdb4r::logger.warn "expected return code 200, but received #{response.code}"
           elseif 200 != response.code
-            raise OrientdbError, "unexpeted return code, code=#{response.code}"
+            raise OrientdbError, "unexpected return code, code=#{response.code}"
           end
         end
 

--- a/test/test_ddo.rb
+++ b/test/test_ddo.rb
@@ -112,7 +112,7 @@ class TestDdo < Test::Unit::TestCase
 
     # CLASS extends super_class
     @client.create_class(CLASS, :extends => super_clazz);
-    assert_raise Orientdb4r::OrientdbError do @client.drop_class(super_clazz, :mode => :strict); end
+    assert_raise Orientdb4r::ClientError do @client.drop_class(super_clazz, :mode => :strict); end
     assert_nothing_thrown do @client.get_class(super_clazz); end # still there
     @client.drop_class(CLASS);
     assert_nothing_thrown do @client.drop_class(super_clazz, :mode => :strict); end


### PR DESCRIPTION
This PR will enable us to do finer-grained error Orientdb error handling.

No way to test the new use of `ConnectionError` due to lack of stubbing/mocking library, unfortunately.
